### PR TITLE
Make sure upgrade.js is included in published package.

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "author": "Aaron VonderHaar <gruen0aermel@gmail.com>",
   "license": "MIT",
   "files": [
+    "upgrade.js",
     "src/**/*.js"
   ],
   "dependencies": {


### PR DESCRIPTION
It seems like the recent addition of the `files` property to `package.json` caused the upgrade script to be excluded from the published package.  I'd have expected npm include the files in `bin` anyway to prevent broken installs, but ¯\_(ツ)_/¯