### PR TITLE
make upgrading work for elm 0.19.1

### DIFF
--- a/upgrade.js
+++ b/upgrade.js
@@ -365,13 +365,13 @@ function main(knownPackages) {
     elmJson = {
       type: "application",
       "source-directories": elmPackage["source-directories"],
-      "elm-version": "0.19.0",
+      "elm-version": elmVersion,
       dependencies: {
         direct: {
-          "elm/core": "1.0.2"
+          "elm/core": "1.0.2",
+          "elm/json": "1.1.3"
         },
         indirect: {
-          "elm/json": "1.1.3"
         }
       },
       "test-dependencies": {

--- a/upgrade.js
+++ b/upgrade.js
@@ -371,8 +371,7 @@ function main(knownPackages) {
           "elm/core": "1.0.2",
           "elm/json": "1.1.3"
         },
-        indirect: {
-        }
+        indirect: {}
       },
       "test-dependencies": {
         direct: {},

--- a/upgrade.js
+++ b/upgrade.js
@@ -368,10 +368,11 @@ function main(knownPackages) {
       "elm-version": elmVersion,
       dependencies: {
         direct: {
-          "elm/core": "1.0.2",
-          "elm/json": "1.1.3"
+          "elm/core": "1.0.2"
         },
-        indirect: {}
+        indirect: {
+          "elm/json": "1.1.3"
+        }
       },
       "test-dependencies": {
         direct: {},


### PR DESCRIPTION
fixes #82 

**open question**: The elm compiler in version `0.19.1` seems to emit an [error](https://github.com/elm/compiler/blob/7a32a3a3e47864c4c29a554e367779fad6919dd1/builder/src/Reporting/Exit.hs#L1037-L1045) when `elm/json` is not a direct dependency when an application uses ports or flags. To make it work I moved `elm/json` to the direct dependencies. 

@avh4 Am I understanding this issue right or could there be cases when having `elm/json` as a direct dependency is not desirable?